### PR TITLE
fix: MacOs 15.3.2 + XCode 16.3 = Unable to build iOS nor MacOS #32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.1.1
+- fix building issue with XCode 16.3 #32
+
 ## 1.1.0
 - when calling AudioData.getAudioData is now possible to check if the audio data is the same as before. Useful to visualize waveforms. This is because AudioData.getAudioData returns the current data in the buffer and if it is called before the buffer has been updated, it will return the previous data.
 - better FFT data for a better visualization.

--- a/ios/flutter_recorder.podspec
+++ b/ios/flutter_recorder.podspec
@@ -26,8 +26,8 @@ A new Flutter FFI plugin project.
     'DEFINES_MODULE' => 'YES',
     'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386',
     "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
-    'OTHER_CFLAGS' => '-Ofast -ffast-math -flto -funroll-loops -msse -msse2 -msse3 -pthread',
-    'OTHER_CPLUSPLUSFLAGS' => '-Ofast -ffast-math -flto -funroll-loops -msse -msse2 -msse3 -pthread',
+    'OTHER_CFLAGS' => '-O3 -ffast-math -ffast-math -flto -funroll-loops -pthread',
+    'OTHER_CPLUSPLUSFLAGS' => '-O3 -ffast-math -ffast-math -flto -funroll-loops -pthread',
     'GCC_OPTIMIZATION_LEVEL' => '3',
     # Add audio and threading optimization flags
     'GCC_PREPROCESSOR_DEFINITIONS' => 'MA_NO_RUNTIME_LINKING=1 NDEBUG=1 _REENTRANT=1',

--- a/macos/flutter_recorder.podspec
+++ b/macos/flutter_recorder.podspec
@@ -26,8 +26,8 @@ A new Flutter FFI plugin project.
     'DEFINES_MODULE' => 'YES',
     "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
     # Enhanced optimization flags
-    'OTHER_CFLAGS' => '-Ofast -march=native -mtune=native -ffast-math -flto -funroll-loops -msse -msse2 -msse3 -pthread -Wno-strict-prototypes',
-    'OTHER_CPLUSPLUSFLAGS' => '-Ofast -march=native -mtune=native -ffast-math -flto -funroll-loops -msse -msse2 -msse3 -pthread -Wno-strict-prototypes',
+    'OTHER_CFLAGS' => '-O3 -ffast-math -march=native -mtune=native -ffast-math -flto -funroll-loops -pthread -Wno-strict-prototypes',
+    'OTHER_CPLUSPLUSFLAGS' => '-O3 -ffast-math -march=native -mtune=native -ffast-math -flto -funroll-loops -pthread -Wno-strict-prototypes',
     'GCC_OPTIMIZATION_LEVEL' => '3',
     # Add audio and threading optimization flags
     'GCC_PREPROCESSOR_DEFINITIONS' => 'MA_NO_RUNTIME_LINKING=1 NDEBUG=1 _REENTRANT=1',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   A low-level audio recorder plugin which uses miniaudio as
   backend. Detect silence and save to WAV audio file. Audio
   wave, FFT and volume level can be get in real-time.
-version: 1.1.0
+version: 1.1.1
 issue_tracker: https://github.com/alnitak/flutter_recorder/issues
 homepage: https://github.com/alnitak/flutter_recorder
 maintainer: Marco Bavagnoli (@lildeimos)


### PR DESCRIPTION
## Description

Fixes #32

Seems that with XCode 16.3 the SSE flags are no longer required and are giving errors when building.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
