### PR TITLE
fix listCaptureDevices fails to retrieve devices when the device prefix contains Chinese characters

### DIFF
--- a/src/flutter_recorder.cpp
+++ b/src/flutter_recorder.cpp
@@ -142,7 +142,7 @@ FFI_PLUGIN_EXPORT void flutter_recorder_listCaptureDevices(
         /// check if the device name has some strange chars (happens on Linux)
         for (int n = 0; n < 5; n++)
         {
-            if (d[i].name[n] < 0x20)
+            if (d[i].name[n] < 0x20 && d[i].name[n] >= 0)
                 hasSpecialChar = true;
         }
         if (strlen(d[i].name) <= 5 || hasSpecialChar)


### PR DESCRIPTION
related to alnitak/flutter_soloud#226

## Description

error same as alnitak/flutter_soloud#226

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
