### PR TITLE
fix: macOS cross-compilation

### DIFF
--- a/macos/flutter_recorder.podspec
+++ b/macos/flutter_recorder.podspec
@@ -22,12 +22,12 @@ A new Flutter FFI plugin project.
   s.dependency 'FlutterMacOS'
 
   s.platform = :osx, '10.11'
-  s.pod_target_xcconfig = { 
+  s.pod_target_xcconfig = {
     'DEFINES_MODULE' => 'YES',
     "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
     # Enhanced optimization flags
-    'OTHER_CFLAGS' => '-O3 -ffast-math -march=native -mtune=native -ffast-math -flto -funroll-loops -pthread -Wno-strict-prototypes',
-    'OTHER_CPLUSPLUSFLAGS' => '-O3 -ffast-math -march=native -mtune=native -ffast-math -flto -funroll-loops -pthread -Wno-strict-prototypes',
+    'OTHER_CFLAGS' => '-O3 -ffast-math -flto -funroll-loops -pthread -Wno-strict-prototypes',
+    'OTHER_CPLUSPLUSFLAGS' => '-O3 -ffast-math -flto -funroll-loops -pthread -Wno-strict-prototypes',
     'GCC_OPTIMIZATION_LEVEL' => '3',
     # Add audio and threading optimization flags
     'GCC_PREPROCESSOR_DEFINITIONS' => 'MA_NO_RUNTIME_LINKING=1 NDEBUG=1 _REENTRANT=1',


### PR DESCRIPTION
## Description

Removes -march=native and -mtune=native from the podspec.
As these break cross-compilation of the library for x86_64, while on an arm64 mac.
Which is part of the flutter's compilation for macOS.

The Clang error that was thrown was: "error: unknown target CPU 'apple-m1'"
and it only happened on release builds.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
