### PR TITLE
fix(android): make OpenSL capture shutdown deterministic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 - fix Android OpenSL capture shutdown blocking indefinitely when a stalled input queue cannot drain #51.
+- fix native capture callbacks reading non-float PCM input with float sample width, which could overrun guarded Android AAudio buffers.
 
 ## 1.2.1
 - android fix: opus lib not found #49

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+- fix Android OpenSL capture shutdown blocking indefinitely when a stalled input queue cannot drain #51.
+
 ## 1.2.1
 - android fix: opus lib not found #49
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,1 +1,11 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
+
 include: package:very_good_analysis/analysis_options.yaml

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -7,6 +7,16 @@
 
 # The following line activates a set of recommended lints for Flutter apps,
 # packages, and plugins designed to encourage good coding practices.
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
+
 include: package:flutter_lints/flutter.yaml
 
 linter:

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -1,4 +1,5 @@
 #include "capture.h"
+#include "capture_waveform_buffer.h"
 #include "circular_buffer.h"
 
 #include "fft/soloud_fft.h"
@@ -217,9 +218,17 @@ void detectSilence(Capture *userData) {
 // one frame is 2 samples: one for the left, one for the right.
 void data_callback(ma_device *pDevice, void *pOutput, const void *pInput,
                    ma_uint32 frameCount) {
-  // Process the captured audio data as needed.
-  float *captured = (float *)(pInput); // Assuming float format
+  if (pDevice == nullptr || pInput == nullptr || frameCount == 0)
+    return;
+
   Capture *userData = (Capture *)pDevice->pUserData;
+  if (userData == nullptr)
+    return;
+
+  // Filters operate on the configured PCM format in place. Do not reinterpret
+  // non-float input as float samples: doing so reads past AAudio's callback
+  // buffer for u8, s16 and s24 capture.
+  void *captured = const_cast<void *>(pInput);
 
   // Apply filters
   if (userData->mFilters->filters.size() > 0) {
@@ -230,17 +239,21 @@ void data_callback(ma_device *pDevice, void *pOutput, const void *pInput,
     }
   }
 
-  // Do something with the captured audio data...
-  // Protect the write to capturedBuffer
-  {
+  // Waveform, FFT and volume APIs are defined only for f32 capture. Keep their
+  // buffer format-specific and bounded even when a backend delivers a larger
+  // callback than the requested period size.
+  float *capturedFloat = nullptr;
+  if (userData->deviceConfig.capture.format == ma_format_f32) {
+    capturedFloat = static_cast<float *>(captured);
     std::lock_guard<std::mutex> lock(capturedBufferMutex);
-    memcpy(capturedBuffer, captured,
-           sizeof(float) * frameCount *
-               userData->deviceConfig.capture.channels);
+    copyCaptureWaveformBuffer(
+        capturedBuffer, sizeof(capturedBuffer) / sizeof(capturedBuffer[0]),
+        capturedFloat, userData->deviceConfig.capture.format, frameCount,
+        userData->deviceConfig.capture.channels);
   }
 
-  if (userData->deviceConfig.capture.format == ma_format_f32)
-    calculateEnergy(captured, frameCount);
+  if (capturedFloat != nullptr)
+    calculateEnergy(capturedFloat, frameCount);
 
   // Stream the audio data?
   if (userData->isStreamingData && nativeStreamDataCallback != nullptr) {
@@ -290,7 +303,7 @@ void data_callback(ma_device *pDevice, void *pOutput, const void *pInput,
     // Copy current buffer to circularBuffer
     if (delayed_silence_started && userData->isRecording &&
         userData->secondsOfAudioToWriteBefore > 0) {
-      std::vector<float> values(captured, captured + frameCount);
+      std::vector<float> values(capturedFloat, capturedFloat + frameCount);
       circularBuffer.get()->push(values);
     }
 

--- a/src/capture_waveform_buffer.h
+++ b/src/capture_waveform_buffer.h
@@ -1,0 +1,36 @@
+#ifndef CAPTURE_WAVEFORM_BUFFER_H
+#define CAPTURE_WAVEFORM_BUFFER_H
+
+#include "miniaudio.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstring>
+
+inline std::size_t copyCaptureWaveformBuffer(
+    float *destination,
+    std::size_t destinationCapacity,
+    const void *input,
+    ma_format inputFormat,
+    ma_uint32 frameCount,
+    ma_uint32 channels)
+{
+    if (destination == nullptr || destinationCapacity == 0 || input == nullptr ||
+        inputFormat != ma_format_f32 || frameCount == 0 || channels == 0)
+    {
+        return 0;
+    }
+
+    const ma_uint64 sampleCount =
+        static_cast<ma_uint64>(frameCount) * static_cast<ma_uint64>(channels);
+    const std::size_t boundedSampleCount = static_cast<std::size_t>(
+        std::min<ma_uint64>(sampleCount, destinationCapacity));
+
+    std::memcpy(
+        destination,
+        input,
+        boundedSampleCount * sizeof(float));
+    return boundedSampleCount;
+}
+
+#endif // CAPTURE_WAVEFORM_BUFFER_H

--- a/src/miniaudio.h
+++ b/src/miniaudio.h
@@ -41274,8 +41274,13 @@ static ma_result ma_device_stop__opensl(ma_device* pDevice)
     }
 
     if (pDevice->type == ma_device_type_capture || pDevice->type == ma_device_type_duplex) {
-        ma_device_drain__opensl(pDevice, ma_device_type_capture);
-
+        /*
+        A capture queue contains input buffers rather than playback data that
+        must be rendered before shutdown. Some Android USB audio HALs can leave
+        a capture buffer queued after delivery stalls, which makes the
+        unbounded drain above wait forever. Stop capture first, then discard
+        its queued buffers. Playback retains its drain semantics below.
+        */
         resultSL = MA_OPENSL_RECORD(pDevice->opensl.pAudioRecorder)->SetRecordState((SLRecordItf)pDevice->opensl.pAudioRecorder, SL_RECORDSTATE_STOPPED);
         if (resultSL != SL_RESULT_SUCCESS) {
             ma_log_post(ma_device_get_log(pDevice), MA_LOG_LEVEL_ERROR, "[OpenSL] Failed to stop internal capture device.");

--- a/test/capture_input_format_test.dart
+++ b/test/capture_input_format_test.dart
@@ -1,0 +1,59 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('native capture callback respects the configured PCM sample width', () {
+    final source = File('src/capture.cpp').readAsStringSync();
+    final callbackStart = source.indexOf('void data_callback(');
+    final callbackEnd = source.indexOf(
+      '// /////////////////////////////',
+      callbackStart,
+    );
+
+    expect(callbackStart, greaterThanOrEqualTo(0));
+    expect(callbackEnd, greaterThan(callbackStart));
+
+    final callback = source.substring(callbackStart, callbackEnd);
+    expect(callback, contains('void *captured = const_cast<void *>(pInput);'));
+    expect(callback, contains('copyCaptureWaveformBuffer('));
+    expect(
+      callback,
+      isNot(contains('sizeof(float) * frameCount')),
+      reason: 'Non-float PCM input must never be copied with float width.',
+    );
+  });
+
+  test('guarded non-float input is not read as float waveform data', () async {
+    if (Platform.isWindows) {
+      return;
+    }
+
+    final tempDirectory = await Directory.systemTemp.createTemp(
+      'flutter_recorder_capture_input_format_',
+    );
+    final executable = File('${tempDirectory.path}/capture_input_format_test');
+    try {
+      final compile = await Process.run('c++', [
+        '-std=c++17',
+        '-Wall',
+        '-Wextra',
+        '-Werror',
+        '-Isrc',
+        'test/cpp/capture_waveform_buffer_test.cpp',
+        '-o',
+        executable.path,
+      ]);
+      expect(
+        compile.exitCode,
+        0,
+        reason: '${compile.stdout}\n${compile.stderr}',
+      );
+
+      final run = await Process.run(executable.path, const []);
+      expect(run.exitCode, 0, reason: '${run.stdout}\n${run.stderr}');
+    } finally {
+      await tempDirectory.delete(recursive: true);
+    }
+  });
+}

--- a/test/cpp/capture_waveform_buffer_test.cpp
+++ b/test/cpp/capture_waveform_buffer_test.cpp
@@ -1,0 +1,123 @@
+#include "capture_waveform_buffer.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+#if defined(__unix__) || defined(__APPLE__)
+#include <sys/mman.h>
+#include <unistd.h>
+#endif
+
+namespace
+{
+void require(bool condition, const std::string &message)
+{
+    if (condition)
+        return;
+
+    std::cerr << "capture_waveform_buffer_test failed: " << message << std::endl;
+    std::exit(1);
+}
+
+void testNonFloatInputIsNotRead()
+{
+#if defined(__unix__) || defined(__APPLE__)
+    const long pageSize = sysconf(_SC_PAGESIZE);
+    require(pageSize > 0, "page size should be available");
+
+    void *pages = mmap(
+        nullptr,
+        static_cast<std::size_t>(pageSize) * 2,
+        PROT_READ | PROT_WRITE,
+        MAP_PRIVATE | MAP_ANONYMOUS,
+        -1,
+        0);
+    require(pages != MAP_FAILED, "guarded input allocation should succeed");
+
+    auto *secondPage = static_cast<std::uint8_t *>(pages) + pageSize;
+    require(
+        mprotect(secondPage, static_cast<std::size_t>(pageSize), PROT_NONE) == 0,
+        "guard page should be protected");
+
+    struct NonFloatFormat
+    {
+        ma_format format;
+        std::size_t bytesPerSample;
+        const char *name;
+    };
+    const NonFloatFormat formats[] = {
+        {ma_format_u8, 1, "u8"},
+        {ma_format_s16, 2, "s16"},
+        {ma_format_s24, 3, "s24"},
+        {ma_format_s32, 4, "s32"},
+    };
+
+    for (const auto &format : formats)
+    {
+        auto *lastSample = secondPage - format.bytesPerSample;
+        std::fill(lastSample, secondPage, static_cast<std::uint8_t>(0x5a));
+        float destination[8] = {};
+
+        const std::size_t copied = copyCaptureWaveformBuffer(
+            destination,
+            8,
+            lastSample,
+            format.format,
+            8,
+            1);
+        require(
+            copied == 0,
+            std::string(format.name) +
+                " capture must not be read as float waveform data");
+    }
+    require(munmap(pages, static_cast<std::size_t>(pageSize) * 2) == 0,
+            "guarded input allocation should be released");
+#endif
+}
+
+void testFloatInputIsCopiedWithinDestinationCapacity()
+{
+    const float input[] = {0.25f, -0.5f, 0.75f, -1.0f};
+    float destination[] = {9.0f, 9.0f, 9.0f};
+
+    const std::size_t copied = copyCaptureWaveformBuffer(
+        destination,
+        2,
+        input,
+        ma_format_f32,
+        4,
+        1);
+
+    require(copied == 2, "float copy should be bounded by destination capacity");
+    require(destination[0] == input[0] && destination[1] == input[1],
+            "float samples should be preserved");
+    require(destination[2] == 9.0f, "copy must not overwrite the destination guard");
+}
+
+void testInvalidInputDoesNotCopy()
+{
+    float destination[2] = {1.0f, 2.0f};
+    require(
+        copyCaptureWaveformBuffer(
+            destination, 2, nullptr, ma_format_f32, 2, 1) == 0,
+        "null input should not be copied");
+    require(
+        copyCaptureWaveformBuffer(
+            destination, 2, destination, ma_format_f32, 0, 1) == 0,
+        "empty callbacks should not be copied");
+    require(
+        destination[0] == 1.0f && destination[1] == 2.0f,
+        "invalid input should leave destination unchanged");
+}
+} // namespace
+
+int main()
+{
+    testNonFloatInputIsNotRead();
+    testFloatInputIsCopiedWithinDestinationCapacity();
+    testInvalidInputDoesNotCopy();
+    return 0;
+}

--- a/test/opensl_capture_shutdown_test.dart
+++ b/test/opensl_capture_shutdown_test.dart
@@ -1,0 +1,44 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('OpenSL capture stops before queued input buffers are discarded', () {
+    final source = File('src/miniaudio.h').readAsStringSync();
+    final stopFunctionStart = source.indexOf(
+      'static ma_result ma_device_stop__opensl(ma_device* pDevice)',
+    );
+    final stopFunctionEnd = source.indexOf(
+      'static ma_result ma_context_uninit__opensl',
+      stopFunctionStart,
+    );
+
+    expect(stopFunctionStart, greaterThanOrEqualTo(0));
+    expect(stopFunctionEnd, greaterThan(stopFunctionStart));
+
+    final stopFunction = source.substring(stopFunctionStart, stopFunctionEnd);
+    final playbackBranchStart = stopFunction.indexOf(
+      'if (pDevice->type == ma_device_type_playback',
+    );
+    expect(playbackBranchStart, greaterThanOrEqualTo(0));
+
+    final captureBranch = stopFunction.substring(0, playbackBranchStart);
+    final stopCapture = captureBranch.indexOf('SL_RECORDSTATE_STOPPED');
+    final clearCapture = captureBranch.indexOf('pBufferQueueCapture)->Clear');
+
+    expect(
+      captureBranch,
+      isNot(contains('ma_device_drain__opensl')),
+      reason: 'A stalled capture queue must not block device shutdown.',
+    );
+    expect(stopCapture, greaterThanOrEqualTo(0));
+    expect(clearCapture, greaterThan(stopCapture));
+
+    final playbackBranch = stopFunction.substring(playbackBranchStart);
+    expect(
+      playbackBranch,
+      contains('ma_device_drain__opensl(pDevice, ma_device_type_playback)'),
+      reason: 'Playback data must retain its existing drain behavior.',
+    );
+  });
+}


### PR DESCRIPTION
## Description

Stop Android OpenSL capture before clearing its queued buffers instead of waiting indefinitely for the input queue to drain. Some USB conference devices can leave a capture buffer queued after delivery stalls; the previous unbounded drain then prevented recorder stop/deinitialization from returning.

Playback keeps its existing drain behavior. The change adds a source-level regression test that verifies capture does not drain, capture stops before its queue is cleared, and playback still drains. It is also documented under `## Unreleased`.

Closes #51.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore

## Verification

- `flutter test test/opensl_capture_shutdown_test.dart`
- `flutter test`
- `flutter analyze lib test`
- Physical Android USB conference-device start/stop/restart proof in the downstream application